### PR TITLE
Add Telegram GPT bot example

### DIFF
--- a/telegram_bot/README.md
+++ b/telegram_bot/README.md
@@ -1,0 +1,24 @@
+# Telegram GPT-бот
+
+Простой пример бота для Telegram, который пересылает сообщения в модель GPT-3.5 и отправляет ответ пользователю.
+
+## Требования
+- Python 3.8+
+- Библиотеки `python-telegram-bot` и `openai`
+
+## Установка
+```bash
+pip install python-telegram-bot openai
+```
+
+## Переменные окружения
+Создайте две переменные окружения:
+- `TELEGRAM_TOKEN` — токен вашего бота, полученный у `@BotFather`.
+- `OPENAI_API_KEY` — API-ключ OpenAI.
+
+## Запуск
+```bash
+python bot.py
+```
+
+Бот начнёт опрашивать Telegram и отвечать на входящие текстовые сообщения.

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -1,0 +1,35 @@
+import os
+import openai
+from telegram.ext import Updater, MessageHandler, Filters
+
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+openai.api_key = OPENAI_API_KEY
+
+
+def handle_message(update, context):
+    user_text = update.message.text
+    try:
+        completion = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": user_text}],
+        )
+        reply = completion.choices[0].message["content"].strip()
+    except Exception as e:
+        reply = f"Ошибка: {e}"
+    update.message.reply_text(reply)
+
+
+def main():
+    if not TELEGRAM_TOKEN or not OPENAI_API_KEY:
+        raise RuntimeError("Не заданы переменные TELEGRAM_TOKEN и OPENAI_API_KEY")
+    updater = Updater(TELEGRAM_TOKEN, use_context=True)
+    dp = updater.dispatcher
+    dp.add_handler(MessageHandler(Filters.text & ~Filters.command, handle_message))
+    updater.start_polling()
+    updater.idle()
+
+
+if __name__ == "__main__":
+    main()

--- a/telegram_bot/requirements.txt
+++ b/telegram_bot/requirements.txt
@@ -1,0 +1,2 @@
+python-telegram-bot
+openai


### PR DESCRIPTION
## Summary
- add a simple Telegram bot using GPT-3.5 via OpenAI API
- include Russian README with setup instructions
- add required dependencies list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847e67a6d488330bd40ea039154e978